### PR TITLE
Fix escaping of unit names

### DIFF
--- a/library/systemd_escape.py
+++ b/library/systemd_escape.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2020, Will Szumski <will@stackhpc.com>
+# Licensed under the Apache2 license.
+
+from ansible.module_utils.basic import AnsibleModule
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: systemd_escape
+
+short_description: Escapes strings with the systemd-escape utility.
+
+version_added: "N/A"
+
+description:
+    - "Returns string as escaped by systemd-escape"
+
+options:
+    strings:
+        description:
+            - List of strings to escape
+        type: list
+
+author:
+    - Will Szumski
+'''
+
+EXAMPLES = '''
+# Escapes a list of strings
+- name: Escape strings for systemd
+  systemd_escape:
+    strings:
+      - test-string
+  register: result
+'''
+
+RETURN = '''
+escaped:
+    description: A dictionary mapping the original string to the escaped string.
+    type: dict
+    returned: always
+'''
+
+
+def escape(module):
+    result = {}
+    for string in module.params["strings"]:
+        if not isinstance(string, str):
+            module.fail_json(
+                msg="Received invalid argument. %s is not a string" % string
+            )
+        _rc, stdout, _stderr = module.run_command(
+            ["systemd-escape", string], check_rc=True)
+        # NOTE(wszumski): _rc will always be equal to zero here due to check_rc above.
+        result[string] = stdout.strip()
+    return result
+
+
+def run_module():
+
+    module_args = {
+        "strings": {"type": "list"}
+    }
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    result = dict(
+        changed=False,
+        luks_devices=[]
+    )
+
+    result['escaped'] = escape(module)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/library/systemd_escape.py
+++ b/library/systemd_escape.py
@@ -75,7 +75,7 @@ def run_module():
 
     result = dict(
         changed=False,
-        luks_devices=[]
+        escaped={},
     )
 
     result['escaped'] = escape(module)

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,6 @@
       - device: /dev/loop0
         name: cryptotest
       - device: /dev/loop1
-        name: cryptotest1
+        name: crypto-test1
   roles:
     - role: stackhpc.luks

--- a/molecule/default/tests/test_creation.py
+++ b/molecule/default/tests/test_creation.py
@@ -9,5 +9,5 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_crypto_devices(host):
     f = host.file('/dev/mapper/cryptotest')
     assert f.exists
-    f = host.file('/dev/mapper/cryptotest1')
+    f = host.file('/dev/mapper/crypto-test1')
     assert f.exists

--- a/molecule/docker/converge.yml
+++ b/molecule/docker/converge.yml
@@ -6,6 +6,6 @@
       - device: /dev/loop0
         name: cryptotest
       - device: /dev/loop1
-        name: cryptotest1
+        name: crypto-test1
   roles:
     - role: stackhpc.luks

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -16,7 +16,7 @@ def test_key_files_exist(host):
 
 @pytest.mark.parametrize('file, content', [
     ("/etc/crypttab", "cryptotest /dev/loop0 /etc/luks-keys/dev-loop0"),
-    ("/etc/crypttab", "cryptotest1 /dev/loop1 /etc/luks-keys/dev-loop1")
+    ("/etc/crypttab", "crypto-test1 /dev/loop1 /etc/luks-keys/dev-loop1")
 ])
 def test_crypttab(host, file, content):
     file = host.file(file)

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -52,13 +52,18 @@
   become: true
   with_items: "{{ luks_devices }}"
 
+- name: Escape device names
+  systemd_escape:
+    strings: "{{ luks_devices | map(attribute='name') | list }}"
+  register: systemd_escape
+
 - name: Setup devices
   vars:
     mode: *mode
   systemd:
     daemon_reload: true
     state: started
-    name: systemd-cryptsetup@{{ item.name }}.service
+    name: systemd-cryptsetup@{{ systemd_escape.escaped[item.name] }}.service
   with_items: "{{ luks_devices }}"
   when: mode == "keyfile"
   become: true


### PR DESCRIPTION
Units with dashes in the name fail to load, see:

https://www.freedesktop.org/software/systemd/man/systemd-escape.html