### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,5 @@
 ---
+# Based on ansible-lint config
 extends: default
 
 rules:
@@ -8,12 +9,25 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
-  line-length: disable
-  truthy: disable
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
   comments-indentation: disable
-
-ignore: |
-  roles
-  virtenv
-  venv
-  .tox
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,7 +10,7 @@
           # For /usr/lib/systemd/system-generators/systemd-cryptsetup-generator. In
           # RedHat 7, the was included in the systemd package.
           - systemd-udev
-        required: "{{ ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8' }}"
+        required: "{{ ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8' }}"
       - packages:
           - clevis-systemd
           - clevis-luks

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ docker
 ansible-lint
 flake8
 testinfra
+yamllint

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,7 @@ whitelist_externals =
     vagrant
 passenv = MOLECULE_IMAGE SCENARIO
 commands =
+  ln -s . ansible-role-luks
   molecule --debug test {posargs}
+  unlink ansible-role-luks
 changedir={toxinidir}


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars